### PR TITLE
Feat: contact highlight

### DIFF
--- a/src/components/ContactsList/ContactHeaderRow.jsx
+++ b/src/components/ContactsList/ContactHeaderRow.jsx
@@ -1,7 +1,35 @@
-import React from 'react'
+import React, { useContext, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 
-const ContactHeaderRow = props => <div className="divider">{props.header}</div>
+import HighlightedContactContext from '../Contexts/HighlightedContact'
+
+const ContactHeaderRow = ({ header }) => {
+  const { highlightedContact } = useContext(HighlightedContactContext)
+  const dividerRef = useRef(null)
+
+  useEffect(() => {
+    if (
+      dividerRef &&
+      highlightedContact.length === 1 &&
+      highlightedContact.slice(0, 1) === header
+    ) {
+      // go as high as posible to make sure the fixed divider doesn't hide the first contact row
+      dividerRef.current.scrollIntoView(false)
+      dividerRef.current.scrollIntoView()
+    }
+  }, [highlightedContact, header])
+
+  return (
+    <div className="divider" ref={dividerRef}>
+      {highlightedContact.length > 0 &&
+      highlightedContact.slice(0, 1) === header ? (
+        <b>{highlightedContact}</b>
+      ) : (
+        header
+      )}
+    </div>
+  )
+}
 
 ContactHeaderRow.propTypes = {
   header: PropTypes.string.isRequired

--- a/src/components/ContactsList/Contacts/ContactName.jsx
+++ b/src/components/ContactsList/Contacts/ContactName.jsx
@@ -1,9 +1,20 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
+import HighlightedContactContext from '../../Contexts/HighlightedContact'
+import useQueryHighlightText from '../Hooks/useQueryHighlightText'
+
 const ContactName = ({ displayName, familyName }) => {
+  const { highlightedContact } = useContext(HighlightedContactContext)
+
   const namesToDisplay = (displayName && displayName.split(' ')) || []
+
+  const highlightedFamilyName = useQueryHighlightText(
+    familyName,
+    highlightedContact
+  )
+
   return (
     <div className="u-ellipsis u-ml-1">
       {namesToDisplay.map((name, key) => (
@@ -11,7 +22,7 @@ const ContactName = ({ displayName, familyName }) => {
           key={`display-${key}`}
           className={cx({ 'u-fw-bold': name === familyName })}
         >
-          {name}
+          {name === familyName ? highlightedFamilyName : name}
           &nbsp;
         </span>
       ))}

--- a/src/components/ContactsList/ContactsList.jsx
+++ b/src/components/ContactsList/ContactsList.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
 import flag from 'cozy-flags'
@@ -10,55 +10,60 @@ import ContactsEmptyList from './ContactsEmptyList'
 import ContactRow from './ContactRow'
 import ContactHeaderRow from './ContactHeaderRow'
 
+import useContactHighlight from './Hooks/useContactHighlight'
 import withSelection from '../Selection/selectionContainer'
 
-class ContactsList extends Component {
-  render() {
-    const { clearSelection, contacts, selection, selectAll, t } = this.props
+const ContactsList = ({
+  clearSelection,
+  contacts,
+  selection,
+  selectAll,
+  t
+}) => {
+  useContactHighlight()
 
-    if (contacts.length === 0) {
-      return <ContactsEmptyList />
-    } else {
-      const isAllContactsSelected = contacts.length === selection.length
-      const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
+  if (contacts.length === 0) {
+    return <ContactsEmptyList />
+  } else {
+    const isAllContactsSelected = contacts.length === selection.length
+    const categorizedContacts = categorizeContacts(contacts, t('empty-list'))
 
-      return (
-        <div className="list-wrapper">
-          {flag('select-all-contacts') && (
-            <div>
-              <Button
-                label={
-                  isAllContactsSelected ? t('unselect-all') : t('select-all')
-                }
-                theme="secondary"
-                onClick={() =>
-                  isAllContactsSelected ? clearSelection() : selectAll(contacts)
-                }
-              />
-            </div>
-          )}
-          <ol className="list-contact">
-            {Object.entries(categorizedContacts).map(([header, contacts]) => (
-              <li key={`cat-${header}`}>
-                <ContactHeaderRow key={header} header={header} />
-                <ol className="sublist-contact">
-                  {contacts.map(contact => (
-                    <li key={`contact-${contact._id}`}>
-                      <ContactRow
-                        id={contact._id}
-                        key={contact._id}
-                        contact={contact}
-                      />
-                    </li>
-                  ))}
-                </ol>
-              </li>
-            ))}
-          </ol>
-          <div />
-        </div>
-      )
-    }
+    return (
+      <div className="list-wrapper">
+        {flag('select-all-contacts') && (
+          <div>
+            <Button
+              label={
+                isAllContactsSelected ? t('unselect-all') : t('select-all')
+              }
+              theme="secondary"
+              onClick={() =>
+                isAllContactsSelected ? clearSelection() : selectAll(contacts)
+              }
+            />
+          </div>
+        )}
+        <ol className="list-contact">
+          {Object.entries(categorizedContacts).map(([header, contacts]) => (
+            <li key={`cat-${header}`}>
+              <ContactHeaderRow key={header} header={header} />
+              <ol className="sublist-contact">
+                {contacts.map(contact => (
+                  <li key={`contact-${contact._id}`}>
+                    <ContactRow
+                      id={contact._id}
+                      key={contact._id}
+                      contact={contact}
+                    />
+                  </li>
+                ))}
+              </ol>
+            </li>
+          ))}
+        </ol>
+        <div />
+      </div>
+    )
   }
 }
 ContactsList.propTypes = {

--- a/src/components/ContactsList/Hooks/useContactHighlight.js
+++ b/src/components/ContactsList/Hooks/useContactHighlight.js
@@ -1,0 +1,34 @@
+import { useCallback, useContext, useEffect } from 'react'
+
+import HighlightedContactContext from '../../Contexts/HighlightedContact'
+
+const useContactHighlight = () => {
+  const { highlightedContact, setHighlightedContact } = useContext(
+    HighlightedContactContext
+  )
+
+  const keydownHandler = useCallback(
+    ({ key }) => {
+      if (key === 'Backspace') {
+        setHighlightedContact(highlightedContact.slice(0, -1))
+        return
+      }
+
+      if (/^\w{1}$/.test(key)) {
+        setHighlightedContact(highlightedContact + key.toLowerCase())
+        return
+      }
+    },
+    [highlightedContact, setHighlightedContact]
+  )
+
+  useEffect(() => {
+    window.addEventListener('keydown', keydownHandler)
+
+    return () => {
+      window.removeEventListener('keydown', keydownHandler)
+    }
+  }, [keydownHandler])
+}
+
+export default useContactHighlight

--- a/src/components/ContactsList/Hooks/useQueryHighlightText.jsx
+++ b/src/components/ContactsList/Hooks/useQueryHighlightText.jsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from 'react'
+
+// adapted from cozy-bar
+// @TODO share this function
+export const normalizeString = str =>
+  str
+    .toString()
+    .toLowerCase()
+    .replace(/\//g, ' ')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+
+export const highlightQueryTerm = (text, query) => {
+  if (!text || !query) {
+    return text
+  }
+
+  const normalizedQuery = normalizeString(query)
+  const normalizedText = normalizeString(text)
+
+  if (normalizedText.indexOf(normalizedQuery) !== 0) {
+    return text
+  }
+
+  const to = normalizedQuery.length
+
+  return [<b key={0}>{text.slice(0, to)}</b>, text.slice(to)]
+}
+
+const useQueryHighlightText = (text, query) => {
+  return useMemo(() => highlightQueryTerm(text, query), [text, query])
+}
+
+export default useQueryHighlightText

--- a/src/components/ContactsList/Hooks/useQueryHighlightText.spec.js
+++ b/src/components/ContactsList/Hooks/useQueryHighlightText.spec.js
@@ -1,0 +1,41 @@
+import renderer from 'react-test-renderer'
+import { renderHook } from '@testing-library/react-hooks'
+
+import useQueryHighlightText from './useQueryHighlightText'
+
+describe('useQueryHighlightText', () => {
+  it('should not highlight a query if not found in the text', () => {
+    const { result } = renderHook(() =>
+      useQueryHighlightText('nice view', 'tree')
+    )
+    expect(result.current).toEqual('nice view')
+  })
+
+  it('should highlight a query if found in the text', () => {
+    const { result } = renderHook(() =>
+      useQueryHighlightText('nice view', 'nice')
+    )
+    expect(renderer.create(result.current).toJSON()).toMatchInlineSnapshot(`
+      Array [
+        <b>
+          nice
+        </b>,
+        " view",
+      ]
+    `)
+  })
+
+  it('should compare normalized query and text', () => {
+    const { result } = renderHook(() =>
+      useQueryHighlightText('nïce view', 'nicé')
+    )
+    expect(renderer.create(result.current).toJSON()).toMatchInlineSnapshot(`
+      Array [
+        <b>
+          nïce
+        </b>,
+        " view",
+      ]
+  `)
+  })
+})

--- a/src/components/ContentResult.jsx
+++ b/src/components/ContentResult.jsx
@@ -5,6 +5,7 @@ import { Content } from 'cozy-ui/transpiled/react/Layout'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
+import { HighlightedContactProvider } from './Contexts/HighlightedContact'
 import SelectedGroupContext from './Contexts/SelectedGroup'
 import Header from './Header'
 import Toolbar from './Toolbar'
@@ -52,7 +53,9 @@ export const ContentResult = ({ contacts, allGroups }) => {
         />
       )}
       <Content>
-        <ContactsList contacts={filteredContactsByGroup} />
+        <HighlightedContactProvider>
+          <ContactsList contacts={filteredContactsByGroup} />
+        </HighlightedContactProvider>
       </Content>
     </>
   )

--- a/src/components/Contexts/HighlightedContact.jsx
+++ b/src/components/Contexts/HighlightedContact.jsx
@@ -1,0 +1,22 @@
+import React, { createContext, useState } from 'react'
+
+const HighlightedContactContext = createContext()
+
+const HighlightedContactProvider = ({ children }) => {
+  const [highlightedContact, setHighlightedContact] = useState('')
+
+  const contextValue = {
+    highlightedContact,
+    setHighlightedContact
+  }
+
+  return (
+    <HighlightedContactContext.Provider value={contextValue}>
+      {children}
+    </HighlightedContactContext.Provider>
+  )
+}
+
+export default HighlightedContactContext
+
+export { HighlightedContactProvider }

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -65,6 +65,9 @@ $reset-list
     align-items center
     flex-basis 30%
     padding-left 2rem
+    b
+        font-weight bolder
+        color: var(--scienceBlue)
 
 .contact-myself
     color coolGrey

--- a/src/styles/contacts.styl
+++ b/src/styles/contacts.styl
@@ -92,6 +92,9 @@ $reset-list
 
 .divider
     @extend $table-divider
+    > b
+        font-weight bolder
+        color: var(--scienceBlue)
 
 // TODO: Find a better way to set the .empty icon size
 .contacts-empty>svg

--- a/src/tests/Applike.jsx
+++ b/src/tests/Applike.jsx
@@ -9,6 +9,7 @@ import langEn from '../locales/en.json'
 import configureStore from '../store/configureStore'
 import getCozyClient from './client'
 import { SelectedGroupProvider } from '../components/Contexts/SelectedGroup'
+import { HighlightedContactProvider } from '../components/Contexts/HighlightedContact'
 
 const store = configureStore(getCozyClient(), null, {})
 
@@ -17,7 +18,9 @@ const AppLike = ({ children, client }) => (
     <Provider store={store}>
       <CozyProvider client={client || getCozyClient()}>
         <I18n lang={'en'} dictRequire={() => langEn}>
-          <SelectedGroupProvider>{children}</SelectedGroupProvider>
+          <SelectedGroupProvider>
+            <HighlightedContactProvider>{children}</HighlightedContactProvider>
+          </SelectedGroupProvider>
         </I18n>
       </CozyProvider>
     </Provider>


### PR DESCRIPTION
Add a navigation by letter in the contacts list.

When the user enters a key, the corresponding sublist is scrolled at the top.
If they continue to enter keys, the query is displayed in the header row and in the matched family names too.

Possible improvements:
- if the user scrolls the list, the query is not displayed anymore
- it could be great to scroll to the contact row if a unique match is found
- the query is not highlighted in the contact if there is no family name
- the color could be changed if no match is found

![image](https://user-images.githubusercontent.com/10920253/95575822-b0bf4d80-0a2f-11eb-93b3-cb5d6725a281.png)